### PR TITLE
add upgrade deletion previous role/rolebinding support

### DIFF
--- a/pkg/controller/klusterletaddon/klusterlet_addon_crs.go
+++ b/pkg/controller/klusterletaddon/klusterlet_addon_crs.go
@@ -37,10 +37,12 @@ import (
 	"github.com/open-cluster-management/library-go/pkg/templateprocessor"
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -92,11 +94,78 @@ var merger applier.Merger = func(current,
 	return current, update
 }
 
+//deleteOutDatedRoleRoleBindings deletes old role/rolebinding with klusterletaddonconfig ownerRef (controller).
+//it returns nil if no role/rolebinding exist, and it returns error when failed to delete the role/rolebinding
+func deleteOutDatedRoleRoleBinding(
+	addon addons.KlusterletAddon,
+	klusterletaddonconfig *agentv1.KlusterletAddonConfig,
+	client client.Client,
+) error {
+	if klusterletaddonconfig == nil {
+		return nil
+	}
+	//check if the role/rolebinding exist
+	role := &rbacv1.Role{}
+	rolebinding := &rbacv1.RoleBinding{}
+	objs := make([]runtime.Object, 0)
+	objs = append(objs, role)
+	objs = append(objs, rolebinding)
+	var retErr error
+	retErr = nil
+	for _, o := range objs {
+		if err := client.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Name:      addon.GetManagedClusterAddOnName(),
+				Namespace: klusterletaddonconfig.Namespace,
+			}, o); err != nil && errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			retErr = err
+			continue
+		}
+
+		// verify ownerRef
+		if objMetaAccessor, ok := o.(metav1.ObjectMetaAccessor); !ok {
+			log.V(2).Info("Failed to get ObjectMeta")
+			continue
+		} else {
+			ownerRef := metav1.GetControllerOf(objMetaAccessor.GetObjectMeta())
+			if ownerRef == nil {
+				log.V(2).Info("No controller reference of the role, skipping")
+				continue
+			}
+			ownerGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+			if err != nil {
+				log.V(2).Info("Failed to get group from object ownerRef")
+				continue
+			}
+			if ownerRef.Kind != klusterletaddonconfig.Kind ||
+				ownerRef.Name != klusterletaddonconfig.Name ||
+				ownerGV.Group != klusterletaddonconfig.GroupVersionKind().Group {
+				log.V(2).Info("Object is not owned by klusterletaddonconfig. Skipping")
+				continue
+			}
+		}
+
+		if err := client.Delete(context.TODO(), o); err != nil && !errors.IsNotFound(err) {
+			retErr = err
+			continue
+		}
+	}
+
+	return retErr
+}
+
 func createOrUpdateHubKubeConfigResources(
 	klusterletaddonconfig *agentv1.KlusterletAddonConfig,
 	r *ReconcileKlusterletAddon,
 	addon addons.KlusterletAddon) error {
 	componentName := addon.GetAddonName()
+
+	if err := deleteOutDatedRoleRoleBinding(addon, klusterletaddonconfig, r.client); err != nil {
+		log.Info("Failed to delete outdated role/rolebinding. Skipping.", "error message:", err)
+	}
 	//Create the values for the yamls
 	config := struct {
 		ManagedClusterName      string

--- a/pkg/controller/klusterletaddon/klusterlet_addon_crs_test.go
+++ b/pkg/controller/klusterletaddon/klusterlet_addon_crs_test.go
@@ -1171,40 +1171,40 @@ func Test_deleteOutDatedRoleRoleBinding(t *testing.T) {
 	}
 	roleOwned := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
 
 	rolebindingOwned := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
 
 	rolebindingOwnedOther := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
 
 	roleNotOwned := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
 	rolebindingNotOwned := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
 	roleOwnedOther := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "application-manager",
+			Name:      "test-managedcluster-appmgr",
 			Namespace: "test-managedcluster",
 		},
 	}
@@ -1343,27 +1343,29 @@ func Test_deleteOutDatedRoleRoleBinding(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		err := deleteOutDatedRoleRoleBinding(tt.args.addon, tt.args.klusterletaddonconfig, tt.args.client)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("deleteOutDatedRoleRoleBinding() get error %v, wantErr %t", err, tt.wantErr)
-		}
-		// check num of roles
-		roleList := &rbacv1.RoleList{}
-		if err := tt.args.client.List(context.TODO(), roleList); err != nil {
-			t.Errorf("unexpected error when list roles: %v", err)
-		} else if len(roleList.Items) != tt.numRoleLeft {
-			t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
-				len(roleList.Items), tt.numRoleLeft)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			err := deleteOutDatedRoleRoleBinding(tt.args.addon, tt.args.klusterletaddonconfig, tt.args.client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deleteOutDatedRoleRoleBinding() get error %v, wantErr %t", err, tt.wantErr)
+			}
+			// check num of roles
+			roleList := &rbacv1.RoleList{}
+			if err := tt.args.client.List(context.TODO(), roleList); err != nil {
+				t.Errorf("unexpected error when list roles: %v", err)
+			} else if len(roleList.Items) != tt.numRoleLeft {
+				t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
+					len(roleList.Items), tt.numRoleLeft)
+			}
 
-		// check num of rolebindings
-		rolebindingList := &rbacv1.RoleBindingList{}
-		if err := tt.args.client.List(context.TODO(), rolebindingList); err != nil {
-			t.Errorf("unexpected error when list roles: %v", err)
-		} else if len(rolebindingList.Items) != tt.numRolebindingLeft {
-			t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
-				len(rolebindingList.Items), tt.numRolebindingLeft)
-		}
+			// check num of rolebindings
+			rolebindingList := &rbacv1.RoleBindingList{}
+			if err := tt.args.client.List(context.TODO(), rolebindingList); err != nil {
+				t.Errorf("unexpected error when list roles: %v", err)
+			} else if len(rolebindingList.Items) != tt.numRolebindingLeft {
+				t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
+					len(rolebindingList.Items), tt.numRolebindingLeft)
+			}
+		})
 	}
 
 }

--- a/pkg/controller/klusterletaddon/klusterlet_addon_crs_test.go
+++ b/pkg/controller/klusterletaddon/klusterlet_addon_crs_test.go
@@ -23,12 +23,14 @@ import (
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func Test_syncManifestWorkCRs(t *testing.T) {
@@ -1130,4 +1132,238 @@ func Test_getKubeAPIServerCertificate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_deleteOutDatedRoleRoleBinding(t *testing.T) {
+	testscheme := scheme.Scheme
+
+	testscheme.AddKnownTypes(agentv1.SchemeGroupVersion, &agentv1.KlusterletAddonConfig{})
+
+	klusterletaddonconfig1 := &agentv1.KlusterletAddonConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: agentv1.SchemeGroupVersion.String(),
+			Kind:       "KlusterletAddonConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-managedcluster",
+			Namespace: "test-managedcluster",
+		},
+		Spec: agentv1.KlusterletAddonConfigSpec{
+			ApplicationManagerConfig: agentv1.KlusterletAddonConfigApplicationManagerSpec{
+				Enabled: true,
+			},
+		},
+	}
+	klusterletaddonconfig2 := &agentv1.KlusterletAddonConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: agentv1.SchemeGroupVersion.String(),
+			Kind:       "KlusterletAddonConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-managedcluster-2",
+			Namespace: "test-managedcluster",
+		},
+		Spec: agentv1.KlusterletAddonConfigSpec{
+			ApplicationManagerConfig: agentv1.KlusterletAddonConfigApplicationManagerSpec{
+				Enabled: true,
+			},
+		},
+	}
+	roleOwned := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+
+	rolebindingOwned := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+
+	rolebindingOwnedOther := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+
+	roleNotOwned := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+	rolebindingNotOwned := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+	roleOwnedOther := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "application-manager",
+			Namespace: "test-managedcluster",
+		},
+	}
+
+	roleNotRelated1 := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-role-1",
+			Namespace: "test-managedcluster",
+		},
+	}
+
+	roleNotRelated2 := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-role-2",
+			Namespace: "test-managedcluster",
+		},
+	}
+	rolebindingNotRelated := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-rolebinding",
+			Namespace: "test-managedcluster",
+		},
+	}
+	if err := controllerutil.SetControllerReference(klusterletaddonconfig1, roleOwned, testscheme); err != nil {
+		t.Errorf("unexpected error when setting controller reference: %v", err)
+	}
+	if err := controllerutil.SetControllerReference(klusterletaddonconfig1, rolebindingOwned, testscheme); err != nil {
+		t.Errorf("unexpected error when setting controller reference: %v", err)
+	}
+	if err := controllerutil.SetControllerReference(klusterletaddonconfig2, rolebindingOwnedOther, testscheme); err != nil {
+		t.Errorf("unexpected error when setting controller reference: %v", err)
+	}
+	if err := controllerutil.SetControllerReference(klusterletaddonconfig2, roleOwnedOther, testscheme); err != nil {
+		t.Errorf("unexpected error when setting controller reference: %v", err)
+	}
+	if err := controllerutil.SetControllerReference(klusterletaddonconfig1, roleNotRelated1, testscheme); err != nil {
+		t.Errorf("unexpected error when setting controller reference: %v", err)
+	}
+
+	type args struct {
+		client                client.Client
+		addon                 addons.KlusterletAddon
+		klusterletaddonconfig *agentv1.KlusterletAddonConfig
+	}
+
+	tests := []struct {
+		name               string
+		args               args
+		numRoleLeft        int
+		numRolebindingLeft int
+		wantErr            bool
+	}{
+		{
+			name: "role should be deleted",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, roleOwned, klusterletaddonconfig1),
+			},
+			numRoleLeft:        0,
+			numRolebindingLeft: 0,
+			wantErr:            false,
+		},
+		{
+			name: "rolebinding should be deleted",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, rolebindingOwned, klusterletaddonconfig1),
+			},
+			numRoleLeft:        0,
+			numRolebindingLeft: 0,
+			wantErr:            false,
+		},
+		{
+			name: "both role & rolebinding should be deleted",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, roleOwned, rolebindingOwned, klusterletaddonconfig1),
+			},
+			numRoleLeft:        0,
+			numRolebindingLeft: 0,
+			wantErr:            false,
+		},
+		{
+			name: "no owner will be ignored",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, roleNotOwned, rolebindingNotOwned, klusterletaddonconfig1),
+			},
+			numRoleLeft:        1,
+			numRolebindingLeft: 1,
+			wantErr:            false,
+		},
+		{
+			name: "not owned by current will be ignored",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, roleOwnedOther, rolebindingOwnedOther, klusterletaddonconfig1),
+			},
+			numRoleLeft:        1,
+			numRolebindingLeft: 1,
+			wantErr:            false,
+		},
+		{
+			name: "not found will be ignored",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client:                fake.NewFakeClientWithScheme(testscheme, klusterletaddonconfig1),
+			},
+			numRoleLeft:        0,
+			numRolebindingLeft: 0,
+			wantErr:            false,
+		},
+		{
+			name: "not related role/rolebindings will not be removed",
+			args: args{
+				klusterletaddonconfig: klusterletaddonconfig1,
+				addon:                 addons.AppMgr,
+				client: fake.NewFakeClientWithScheme(
+					testscheme,
+					klusterletaddonconfig1,
+					roleNotRelated1,
+					roleNotRelated2,
+					rolebindingNotRelated,
+				),
+			},
+			numRoleLeft:        2,
+			numRolebindingLeft: 1,
+			wantErr:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		err := deleteOutDatedRoleRoleBinding(tt.args.addon, tt.args.klusterletaddonconfig, tt.args.client)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("deleteOutDatedRoleRoleBinding() get error %v, wantErr %t", err, tt.wantErr)
+		}
+		// check num of roles
+		roleList := &rbacv1.RoleList{}
+		if err := tt.args.client.List(context.TODO(), roleList); err != nil {
+			t.Errorf("unexpected error when list roles: %v", err)
+		} else if len(roleList.Items) != tt.numRoleLeft {
+			t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
+				len(roleList.Items), tt.numRoleLeft)
+		}
+
+		// check num of rolebindings
+		rolebindingList := &rbacv1.RoleBindingList{}
+		if err := tt.args.client.List(context.TODO(), rolebindingList); err != nil {
+			t.Errorf("unexpected error when list roles: %v", err)
+		} else if len(rolebindingList.Items) != tt.numRolebindingLeft {
+			t.Errorf("deleteOutDatedRoleRoleBinding() get wrong # of roles left %d, want %d",
+				len(rolebindingList.Items), tt.numRolebindingLeft)
+		}
+	}
+
 }

--- a/test/functional/managed_cluster_addon_test.go
+++ b/test/functional/managed_cluster_addon_test.go
@@ -307,16 +307,6 @@ var _ = Describe("ManagedClusterAddOns", func() {
 				checkStatusConditionNotFound(clientClusterDynamic, mcaName, testNamespace, "Degraded", "True")
 			}
 		})
-		By("Checking Degraded=true when lease expires", func() {
-			for _, crName := range addonCRs {
-				mcaName := mcaMaps[crName]
-				renewTime := time.Now().Add(-time.Second * 6 * 60).Format("2006-01-02T15:04:05.000000Z07:00")
-				lease := newLease(mcaName, testNamespace, renewTime)
-				createNewUnstructured(clientClusterDynamic, gvrLease,
-					lease, mcaName, testNamespace)
-				checkStatusCondition(clientClusterDynamic, mcaName, testNamespace, "Degraded", "True")
-			}
-		})
 	})
 })
 


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/10003

Updates:
- added logic to delete leftover role/rolebindings during acm upgrade 

Tests:
- [x] unit test
- [x] fresh install still works (lease updated)
- [x] when upgrade ACM, old role/rolebindings are deleted
- [x] after upgrade, still works (lease updated, no obvious error in addon log)