### PR TITLE
Add management workload annotations

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       name: klusterlet-addon-controller
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: klusterlet-addon-controller
     spec:

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -3,4 +3,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: open-cluster-management

--- a/overlays/community/deployment.yaml
+++ b/overlays/community/deployment.yaml
@@ -1,5 +1,4 @@
 # Copyright Contributors to the Open Cluster Management project
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,11 +6,10 @@ metadata:
   namespace: open-cluster-management
 spec:
   template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: klusterlet-addon-controller
         image: quay.io/open-cluster-management/klusterlet-addon-controller:latest
-
-
-           
-    

--- a/overlays/test/with_sha/deployment.yaml
+++ b/overlays/test/with_sha/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: open-cluster-management
 spec:
   template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       securityContext:
         fsGroup: 2000

--- a/pkg/components/addon-operator/v1/klusterlet_addon_operator.go
+++ b/pkg/components/addon-operator/v1/klusterlet_addon_operator.go
@@ -121,6 +121,9 @@ func NewNamespace() *corev1.Namespace {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: KlusterletAddonNamespace,
+			Annotations: map[string]string{
+				"workload.openshift.io/allowed": "management",
+			},
 		},
 	}
 }
@@ -160,6 +163,9 @@ func NewDeployment(instance *agentv1.KlusterletAddonConfig, namespace string) (*
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 					Labels: map[string]string{
 						"name": KlusterletAddonOperator,
 					},


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Ian Miller <imiller@redhat.com>