### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for klusterlet-addon-controller-acm-214

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -13,8 +13,9 @@ RUN chmod g+w . && \
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
-    name="klusterlet-addon-controller" \
+    name="rhacm2/klusterlet-addon-controller-rhel9" \
     com.redhat.component="klusterlet-addon-controller" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
     io.k8s.description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
     summary="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
