### PR TITLE
fix: update user_setup script to properly add user to /etc/passwd

### DIFF
--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -2,12 +2,10 @@
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
-
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # no need for this script to remain in the image after running
 rm $0

--- a/build/install-dependencies.sh
+++ b/build/install-dependencies.sh
@@ -14,7 +14,7 @@ export GO111MODULE=off
 # Go tools
 
 if ! which patter > /dev/null; then      echo "Installing patter ..."; go install github.com/apg/patter@latest; fi
-if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; go install github.com/wadey/gocovmerge@latest; fi
+if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; go install github.com/alexfalkowski/gocovmerge/v2@v2.14.0; fi
 # if ! which swagger > /dev/null; then     echo "Installing swagger..."; go install github.com/rws-github/go-swagger/cmd/swagger; fi
 if ! which golangci-lint > /dev/null; then
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.1

--- a/build/run-unit-tests.sh
+++ b/build/run-unit-tests.sh
@@ -11,7 +11,7 @@
 
 _script_dir=$(dirname "$0")
 
-if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; pushd $(mktemp -d) && GOSUMDB=off go install github.com/wadey/gocovmerge@latest && popd; fi
+if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; pushd $(mktemp -d) && GOSUMDB=off go install github.com/alexfalkowski/gocovmerge/v2@v2.14.0 && popd; fi
 if ! which patter > /dev/null; then      echo "Installing patter ..."; pushd $(mktemp -d) && GOSUMDB=off go install github.com/apg/patter@latest && popd; fi
 
 export GOFLAGS=""


### PR DESCRIPTION
## Summary
- Update user_setup script to directly add user entries to /etc/passwd instead of making it group-writable
- Improve security by avoiding unnecessary file permissions  
- Add proper variable quoting for shell safety
- Update gocovmerge dependency to v2.14.0

## Changes
- Add user entry to /etc/passwd with proper format using echo command
- Remove `chmod g+rw /etc/passwd` command that made the file writable by group
- Add proper quoting for `${HOME}` and `${USER_UID}:0` variables
- Update gocovmerge from github.com/wadey/gocovmerge@latest to github.com/alexfalkowski/gocovmerge/v2@v2.14.0

🤖 Generated with [Claude Code](https://claude.ai/code)