### PR TITLE
chore: update golangci-lint to sdk-go centralized management

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,103 @@
+# golangci-lint v2.x configuration
+# Compatible with golangci-lint v2.0.0+
+# Documentation: https://golangci-lint.run/docs/configuration/
+# Migration guide: https://golangci-lint.run/docs/product/migration-guide/
+
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  # Use 'none' as default and explicitly enable linters
+  # Options: none, standard, all, fast
+  default: none
+
+  enable:
+    # Default/standard linters
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck  # includes gosimple and stylecheck
+    - unused
+
+    # Code style
+    - misspell
+    - unconvert
+    - unparam
+    - nakedret
+    - prealloc
+    - copyloopvar  # replaces exportloopref in v2
+    - revive
+
+  settings:
+    misspell:
+      locale: US
+
+    nakedret:
+      max-func-lines: 30
+
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+
+  # Exclusions configuration (v2 style)
+  exclusions:
+    # Use presets for common exclusions
+    # Options: comments, std-error-handling, common-false-positives, legacy
+    presets:
+      - comments
+      - std-error-handling
+
+    # Generated files handling: strict, lax, or disable
+    generated: strict
+
+    rules:
+      # Exported type names that stutter (e.g., grpc.GRPCServer) cannot be renamed
+      # without breaking external consumers of this SDK.
+      - linters: [revive]
+        text: "exported: type name will be used as"
+      # Exported functions returning unexported types are part of the public API
+      # and cannot be changed without breaking external consumers.
+      - linters: [revive]
+        text: "unexported-return: exported func"
+      # Package names (common, utils, util) cannot be renamed without breaking
+      # import paths for external consumers.
+      - linters: [revive]
+        text: "avoid meaningless package names"
+
+    # Paths to exclude from all linting
+    paths:
+      - _test\.go
+      - ^e2e/
+      - zz_generated\.deepcopy\.go
+
+# Formatters are separate from linters in v2
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+  settings:
+    goimports:
+      local-prefixes:
+        - open-cluster-management.io
+        - github.com/stolostron

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 


### PR DESCRIPTION
## Summary
- Migrate golangci-lint runner from `stolostron/acm-infra` to `open-cluster-management-io/sdk-go` centralized lint management
- Add local `.golangci.yml` with golangci-lint v2 configuration for reliable config resolution when the script is invoked via `curl | bash`
- No changes to the `make lint` interface — existing workflow remains the same

## Changes
- **Makefile**: Update lint target URL from `stolostron/acm-infra/main/scripts/lint/run-lint.sh` to `open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh`
- **`.golangci.yml`** (new): Add local golangci-lint v2 configuration following the [sdk-go lint guidelines](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/lint/README-golangci-lint.md), which takes priority in the script's config resolution

## Motivation
Follow the centralized golangci-lint management guidelines from sdk-go for consistent linting configuration across open-cluster-management repositories.

## Test plan
- [x] `make lint` passes with 0 issues
- [x] YAML configuration validated with `yq`


🤖 Generated with [Claude Code](https://claude.com/claude-code)