### PR TITLE
chore: migrate lint to sdk-go centralized golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,101 @@
+# golangci-lint v2.x configuration
+# Compatible with golangci-lint v2.0.0+
+# Documentation: https://golangci-lint.run/docs/configuration/
+# Migration guide: https://golangci-lint.run/docs/product/migration-guide/
+
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  # Use 'none' as default and explicitly enable linters
+  # Options: none, standard, all, fast
+  default: none
+
+  enable:
+    # Default/standard linters
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck  # includes gosimple and stylecheck
+    - unused
+
+    # Code style
+    - misspell
+    - unconvert
+    - unparam
+    - nakedret
+    - prealloc
+    - copyloopvar  # replaces exportloopref in v2
+    - revive
+
+  settings:
+    misspell:
+      locale: US
+
+    nakedret:
+      max-func-lines: 30
+
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+
+  # Exclusions configuration (v2 style)
+  exclusions:
+    # Use presets for common exclusions
+    # Options: comments, std-error-handling, common-false-positives, legacy
+    presets:
+      - comments
+      - std-error-handling
+
+    # Generated files handling: strict, lax, or disable
+    generated: strict
+
+    rules:
+      # Exported type names that stutter (e.g., grpc.GRPCServer) cannot be renamed
+      # without breaking external consumers of this SDK.
+      - linters: [revive]
+        text: "exported: type name will be used as"
+      # Exported functions returning unexported types are part of the public API
+      # and cannot be changed without breaking external consumers.
+      - linters: [revive]
+        text: "unexported-return: exported func"
+      # Package names (common, utils, util) cannot be renamed without breaking
+      # import paths for external consumers.
+      - linters: [revive]
+        text: "avoid meaningless package names"
+
+    # Paths to exclude from all linting
+    paths:
+      - _test\.go
+      - ^e2e/
+      - zz_generated\.deepcopy\.go
+
+# Formatters are separate from linters in v2
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+  settings:
+    goimports:
+      local-prefixes: open-cluster-management.io

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 	manifestworkv1 "open-cluster-management.io/api/work/v1"

--- a/pkg/apis/agent/v1/image_utils.go
+++ b/pkg/apis/agent/v1/image_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/addon/add_manager.go
+++ b/pkg/controller/addon/add_manager.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -20,6 +20,7 @@ import (
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/common"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/globalproxy/add_manager.go
+++ b/pkg/controller/globalproxy/add_manager.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/managedcluster/add_manager.go
+++ b/pkg/controller/managedcluster/add_manager.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 


### PR DESCRIPTION
## Summary

- Update the Makefile `lint` target to use the centralized golangci-lint script from `open-cluster-management-io/sdk-go` instead of `stolostron/acm-infra`, following the [migration guide](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/lint/README-golangci-lint.md)
- Add `.golangci.yml` with the standard sdk-go golangci-lint v2 configuration for local config priority
- Fix goimports grouping to properly separate `open-cluster-management.io/` imports into their own group

## Changes

| File | Change |
|------|--------|
| `Makefile` | Updated lint script URL to `open-cluster-management-io/sdk-go` |
| `.golangci.yml` | Added standard golangci-lint v2 config from sdk-go |
| `cmd/manager/main.go` | Fixed goimports grouping |
| `pkg/apis/agent/v1/image_utils.go` | Fixed goimports grouping |
| `pkg/controller/addon/add_manager.go` | Fixed goimports grouping |
| `pkg/controller/addon/klusterlet_addon_controller.go` | Fixed goimports grouping |
| `pkg/controller/globalproxy/add_manager.go` | Fixed goimports grouping |
| `pkg/controller/managedcluster/add_manager.go` | Fixed goimports grouping |

## Verification

- `make lint` passes with 0 issues using golangci-lint v2.8.0
- No breaking changes introduced — only import ordering and lint configuration changes