### PR TITLE
chore: adopt shared golangci-lint scripts from sdk-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 	manifestworkv1 "open-cluster-management.io/api/work/v1"

--- a/pkg/apis/agent/v1/image_utils.go
+++ b/pkg/apis/agent/v1/image_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/addon/add_manager.go
+++ b/pkg/controller/addon/add_manager.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -20,6 +20,7 @@ import (
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/common"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/globalproxy/add_manager.go
+++ b/pkg/controller/globalproxy/add_manager.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/managedcluster/add_manager.go
+++ b/pkg/controller/managedcluster/add_manager.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 


### PR DESCRIPTION
## Summary

- Switch the Makefile `lint` target from the `acm-infra` lint script to the shared `sdk-go` lint script (`run-lint.sh`)
- Fix `goimports` formatting in 6 Go source files to comply with the `sdk-go` golangci-lint v2 configuration (which uses `local-prefixes: open-cluster-management.io`)

## Changes

### Makefile
- Updated the `lint` target URL from `https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh` to `https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh`

### Go source files (goimports fix)
Added blank lines to separate `open-cluster-management.io/...` imports into their own group as required by the sdk-go goimports configuration:
- `cmd/manager/main.go`
- `pkg/apis/agent/v1/image_utils.go`
- `pkg/controller/addon/add_manager.go`
- `pkg/controller/addon/klusterlet_addon_controller.go`
- `pkg/controller/globalproxy/add_manager.go`
- `pkg/controller/managedcluster/add_manager.go`

## Motivation

Adopting the shared lint scripts from [sdk-go](https://github.com/open-cluster-management-io/sdk-go/tree/main/ci/lint) ensures all open-cluster-management repositories stay in sync with the same linting configuration and tooling, reducing per-repo maintenance overhead.

## Test plan

- [x] `make lint` passes with 0 issues using the new sdk-go lint script
- [x] No breaking changes — only import formatting and Makefile URL changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)