### PR TITLE
chore: adopt sdk-go shared lint scripts for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 	manifestworkv1 "open-cluster-management.io/api/work/v1"

--- a/pkg/apis/agent/v1/image_utils.go
+++ b/pkg/apis/agent/v1/image_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/apis/agent/v1/image_utils_test.go
+++ b/pkg/apis/agent/v1/image_utils_test.go
@@ -20,6 +20,7 @@ import (
 
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/addon/add_manager.go
+++ b/pkg/controller/addon/add_manager.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -20,6 +20,7 @@ import (
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/common"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller_test.go
+++ b/pkg/controller/addon/klusterlet_addon_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stolostron/klusterlet-addon-controller/pkg/apis"
 	v1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/common"
+
 	"open-cluster-management.io/api/addon/v1alpha1"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/globalproxy/add_manager.go
+++ b/pkg/controller/globalproxy/add_manager.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/managedcluster/add_manager.go
+++ b/pkg/controller/managedcluster/add_manager.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/test/e2e/globalproxy_test.go
+++ b/test/e2e/globalproxy_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/stolostron/klusterlet-addon-controller/pkg/helpers"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot import is idiomatic for ginkgo


### PR DESCRIPTION
## Summary

- Switch the Makefile `lint` target from `stolostron/acm-infra` to `open-cluster-management-io/sdk-go` shared lint scripts, aligning this repository with the OCM community's centralized golangci-lint v2 management
- Fix `goimports` grouping across Go source files to comply with the sdk-go configuration which uses `open-cluster-management.io` as the local import prefix (separating it from `github.com/stolostron` third-party imports)

## Changes

- **Makefile**: Updated the `lint` target to curl the `run-lint.sh` script from `open-cluster-management-io/sdk-go` instead of `stolostron/acm-infra`
- **Go files** (10 files): Added blank lines to properly separate `open-cluster-management.io/*` imports (local prefix) from `github.com/stolostron/*` imports (third-party) per the sdk-go goimports configuration

## Verification

- `make lint` passes with 0 issues using the new sdk-go lint configuration