### PR TITLE
chore: adopt sdk-go shared lint scripts for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,18 +17,6 @@ import (
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/stolostron/klusterlet-addon-controller/pkg/apis"
-	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
-	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
-	"github.com/stolostron/klusterlet-addon-controller/version"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
-	manifestworkv1 "open-cluster-management.io/api/work/v1"
-
-	// "github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	// kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,6 +27,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/stolostron/klusterlet-addon-controller/pkg/apis"
+	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
+	"github.com/stolostron/klusterlet-addon-controller/version"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
+	manifestworkv1 "open-cluster-management.io/api/work/v1"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/pkg/apis/agent/v1/image_utils.go
+++ b/pkg/apis/agent/v1/image_utils.go
@@ -13,17 +13,15 @@ import (
 	"fmt"
 	"os"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
 //	var defaultComponentImageKeyMap = map[string]string{

--- a/pkg/controller/addon/add_manager.go
+++ b/pkg/controller/addon/add_manager.go
@@ -3,19 +3,19 @@ package addon
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -20,6 +20,7 @@ import (
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/common"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/globalproxy/add_manager.go
+++ b/pkg/controller/globalproxy/add_manager.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/managedcluster/add_manager.go
+++ b/pkg/controller/managedcluster/add_manager.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 


### PR DESCRIPTION
## Summary

- Switch the Makefile `lint` target from `stolostron/acm-infra` to `open-cluster-management-io/sdk-go` shared lint scripts, aligning with the upstream community standard
- Fix goimports formatting issues (import grouping for `github.com/stolostron` and `open-cluster-management.io` local prefixes) flagged by the new linter configuration
- No local golangci-lint config files are created; the remote `run-lint.sh` script auto-downloads the shared config from sdk-go

## Changes

- **Makefile**: Updated lint target URL from `stolostron/acm-infra/main/scripts/lint/run-lint.sh` to `open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh`
- **Go source files** (7 files): Fixed goimports formatting to properly separate local imports (`github.com/stolostron/*`, `open-cluster-management.io/*`) into their own import group

## Test plan

- [x] `make lint` passes with 0 issues using the new sdk-go lint scripts