### PR TITLE
Adopt shared lint scripts from sdk-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ request-destruct:
 .PHONY: lint
 ## Runs linter against go files
 lint:
-	@curl -sSL https://raw.githubusercontent.com/stolostron/acm-infra/main/scripts/lint/run-lint.sh | bash
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 ### HELPER UTILS #######################
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	"github.com/stolostron/klusterlet-addon-controller/pkg/controller"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 	manifestworkv1 "open-cluster-management.io/api/work/v1"

--- a/pkg/apis/agent/v1/image_utils.go
+++ b/pkg/apis/agent/v1/image_utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/apis/agent/v1/image_utils_test.go
+++ b/pkg/apis/agent/v1/image_utils_test.go
@@ -20,6 +20,7 @@ import (
 
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	"github.com/stolostron/klusterlet-addon-controller/version"
+
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/pkg/controller/addon/add_manager.go
+++ b/pkg/controller/addon/add_manager.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/localcluster"
 	imageregistryv1alpha1 "github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 

--- a/pkg/controller/addon/klusterlet_addon_controller_test.go
+++ b/pkg/controller/addon/klusterlet_addon_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
+
 	"open-cluster-management.io/api/addon/v1alpha1"
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 

--- a/pkg/controller/managedcluster/add_manager.go
+++ b/pkg/controller/managedcluster/add_manager.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+
 	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 

--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,7 @@
 // Copyright (c) Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
+//go:build tools
 // +build tools
 
 // Place any runtime dependencies as imports in this file.


### PR DESCRIPTION
## Summary
- Switch the Makefile `lint` target from `acm-infra` to `sdk-go` shared lint configuration (`open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh`)
- Fix goimports formatting across source files to comply with sdk-go's `local-prefixes: open-cluster-management.io` setting
- Add `//go:build tools` directive to `tools.go` (Go 1.17+ format)

## Motivation
The [sdk-go lint integration guide](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/lint/README-golangci-lint.md) provides a shared, centralized lint configuration. By referencing the remote script, all repositories automatically stay in sync with the latest lint rules and golangci-lint version mappings without needing local config files.

## Changes
| File | Change |
|------|--------|
| `Makefile` | Updated `lint` target URL from `acm-infra` to `sdk-go` |
| `cmd/manager/main.go` | Fixed goimports grouping |
| `pkg/apis/agent/v1/image_utils.go` | Fixed goimports grouping |
| `pkg/apis/agent/v1/image_utils_test.go` | Fixed goimports grouping |
| `pkg/controller/addon/add_manager.go` | Fixed goimports grouping |
| `pkg/controller/addon/klusterlet_addon_controller.go` | Fixed goimports grouping |
| `pkg/controller/addon/klusterlet_addon_controller_test.go` | Fixed goimports grouping |
| `pkg/controller/managedcluster/add_manager.go` | Fixed goimports grouping |
| `tools.go` | Added `//go:build tools` directive |

## Test plan
- [x] `make lint` passes with 0 issues
- [x] `make build` passes successfully
- [ ] CI presubmit checks pass