### PR TITLE
chore: migrate envtest setup to sdk-go centralized script [release-2.11]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ kind-config-generated.yaml
 # Folders
 .build-docker
 build/_output
+_output
 build-harness
 build-harness-extensions
 vendor

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export PROJECT_DIR            = $(shell 'pwd')
 export BUILD_DIR              = $(PROJECT_DIR)/build
 export COMPONENT_SCRIPTS_PATH = $(BUILD_DIR)
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 export COMPONENT_NAME ?= $(shell cat ./COMPONENT_NAME 2> /dev/null)
 export COMPONENT_VERSION ?= $(shell cat ./COMPONENT_VERSION 2> /dev/null)
 
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Adopt the centralized envtest setup from `open-cluster-management-io/sdk-go` by adding the `envtest-setup` Makefile target
- The new target downloads and executes `ensure-envtest.sh` from sdk-go to automatically detect K8s version from `go.mod` and configure `KUBEBUILDER_ASSETS`
- The `test` target now depends on `envtest-setup` to ensure kubebuilder binaries are available before running unit tests
- Added `_output/` to `.gitignore` to prevent committing downloaded envtest artifacts

## Changes

### Makefile
- Added `ENSURE_ENVTEST_SCRIPT` variable pointing to the centralized sdk-go envtest script
- Added `envtest-setup` target that downloads and runs the script, exporting `KUBEBUILDER_ASSETS`
- Updated `test` target to depend on `envtest-setup`

### .gitignore
- Added `_output` directory to ignore envtest binary artifacts

## Test plan
- [ ] Verify `make envtest-setup` downloads and configures kubebuilder assets correctly
- [ ] Verify `make test` runs unit tests successfully with envtest setup as prerequisite
- [ ] Verify `_output/` directory is properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)