### PR TITLE
chore: adopt sdk-go shared envtest setup for unit tests [release-2.12]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ kind-config-generated.yaml
 # Folders
 .build-docker
 build/_output
+_output
 build-harness
 build-harness-extensions
 vendor

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ endif
 KUBECONFIG ?= ./.kubeconfig
 KUBECTL?=kubectl
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 .PHONY: deps
 ## Download all project dependencies
 deps:
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target using the centralized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- Make the `test` target depend on `envtest-setup` so `KUBEBUILDER_ASSETS` is automatically configured before running unit tests
- Add `_output` to `.gitignore` to exclude cached envtest binaries (default `ENVTEST_BIN_DIR` is `_output/tools/bin`)

## Details

The `ensure-envtest.sh` script automatically:
1. Detects the Kubernetes version from `k8s.io/api` in `go.mod`
2. Detects the `setup-envtest` branch from `controller-runtime` version
3. Installs `setup-envtest` if not present
4. Downloads appropriate envtest binaries with a version fallback strategy
5. Exports the `KUBEBUILDER_ASSETS` path for test consumption

This replaces manual envtest management with a centralized, version-aware approach consistent across all open-cluster-management repositories.

## Test plan

- [ ] Verify `make test` passes with the new `envtest-setup` dependency
- [ ] Verify `KUBEBUILDER_ASSETS` is correctly set during test execution
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)