### PR TITLE
chore: adopt sdk-go envtest setup for unit tests [release-2.14]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ kind-config-generated.yaml
 
 # Folders
 .build-docker
+_output
 build/_output
 build-harness
 build-harness-extensions

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export PROJECT_DIR            = $(shell 'pwd')
 export BUILD_DIR              = $(PROJECT_DIR)/build
 export COMPONENT_SCRIPTS_PATH = $(BUILD_DIR)
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 export COMPONENT_NAME ?= $(shell cat ./COMPONENT_NAME 2> /dev/null)
 export COMPONENT_VERSION ?= $(shell cat ./COMPONENT_VERSION 2> /dev/null)
 
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Added the centralized `envtest-setup` Makefile target from [sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md), which automatically detects Kubernetes and controller-runtime versions from `go.mod` and provisions the correct envtest binaries (kube-apiserver, etcd, kubectl)
- Made the `test` target depend on `envtest-setup` so envtest binaries are provisioned before running unit tests
- Added `_output/` to `.gitignore` for the envtest binary cache directory (`_output/tools/bin`)

### Notes
- No legacy envtest setup existed in this repo, so this is a net-new addition
- No Go 1.25.x build cache workaround (`go clean -cache`) was present in the test infrastructure, so none was added
- Coverage output directories are already handled by `build/run-unit-tests.sh` via `mkdir -p test/unit/coverage`

## Test plan
- [ ] Verify `make envtest-setup` correctly downloads and provisions envtest binaries
- [ ] Verify `make test` still passes with the new `envtest-setup` dependency
- [ ] Verify `_output/tools/bin` directory is properly gitignored after running envtest-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)