### PR TITLE
chore: adopt sdk-go shared envtest setup [release-2.13]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ kind-config-generated.yaml
 # Folders
 .build-docker
 build/_output
+_output/
 build-harness
 build-harness-extensions
 vendor

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export PROJECT_DIR            = $(shell 'pwd')
 export BUILD_DIR              = $(PROJECT_DIR)/build
 export COMPONENT_SCRIPTS_PATH = $(BUILD_DIR)
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 export COMPONENT_NAME ?= $(shell cat ./COMPONENT_NAME 2> /dev/null)
 export COMPONENT_VERSION ?= $(shell cat ./COMPONENT_VERSION 2> /dev/null)
 
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary
- Add `envtest-setup` Makefile target that uses the shared `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- Wire the `test` target to depend on `envtest-setup` so kubebuilder assets are automatically set up before running unit tests
- Add `_output/` to `.gitignore` for envtest binary caching

## Details
The new `envtest-setup` target automatically:
1. Detects the correct Kubernetes version from `go.mod` (`k8s.io/api`)
2. Detects the correct `setup-envtest` branch from `go.mod` (`controller-runtime`)
3. Downloads and caches envtest binaries in `_output/tools/bin`
4. Exports `KUBEBUILDER_ASSETS` for test consumption

This replaces the need for any local envtest binary management and provides seamless version upgrades when `go.mod` dependencies change.

## Test plan
- [ ] Verify `make envtest-setup` successfully downloads envtest binaries
- [ ] Verify `make test` runs unit tests with `KUBEBUILDER_ASSETS` properly set
- [ ] Verify `_output/` directory is ignored by git after binary download

🤖 Generated with [Claude Code](https://claude.com/claude-code)