### PR TITLE
chore: adopt sdk-go shared envtest setup [release-2.15]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ export GO111MODULE := on
 export GOOS         = $(shell go env GOOS)
 export GOPACKAGES   = $(shell go list ./... | grep -v /vendor | grep -v /build | grep -v /test)
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 export PROJECT_DIR            = $(shell 'pwd')
 export BUILD_DIR              = $(PROJECT_DIR)/build
 export COMPONENT_SCRIPTS_PATH = $(BUILD_DIR)
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Add centralized `envtest-setup` Makefile target using sdk-go's `ensure-envtest.sh` script
- Make `test` target depend on `envtest-setup` to ensure kubebuilder assets are available before running unit tests
- Aligns with the standardized envtest setup approach across OCM repositories

## Details

This PR integrates the shared envtest setup from [sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md) into the Makefile. The `ensure-envtest.sh` script handles:

- Automatic Kubernetes version detection from `go.mod`
- `setup-envtest` branch detection from controller-runtime version
- Binary download and caching
- `KUBEBUILDER_ASSETS` export

### Changes

- **Makefile**: Added `ENSURE_ENVTEST_SCRIPT` variable pointing to the shared script URL
- **Makefile**: Added `envtest-setup` target that downloads and runs the envtest setup script
- **Makefile**: Updated `test` target to depend on `envtest-setup`

### Notes

- No legacy envtest setup existed in this repo (unit tests use fake clients) — this adds the standard setup for future use
- No Go 1.25.x `go clean -cache` workaround was found in the repo, so none was added
- Coverage output directories are already handled by `build/run-unit-tests.sh` (`mkdir -p test/unit/coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)