### PR TITLE
Update envtest setup to use sdk-go ensure-envtest script [main]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ endif
 KUBECONFIG ?= ./.kubeconfig
 KUBECTL?=kubectl
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: deps
 ## Download all project dependencies
 deps:
@@ -54,7 +61,7 @@ copyright-check:
 
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target using the centralized `ensure-envtest.sh` script from `open-cluster-management-io/sdk-go`
- Make `test` target depend on `envtest-setup` so `KUBEBUILDER_ASSETS` is properly configured before running unit tests
- The script auto-detects K8s version from `go.mod` and downloads the appropriate envtest binaries

## Details

This replaces the need for manually installing kubebuilder or setup-envtest by leveraging the shared `ensure-envtest.sh` script maintained in the sdk-go repository. The script:

1. Reads `k8s.io/api` version from `go.mod` to determine the correct K8s version
2. Reads `controller-runtime` version to derive the setup-envtest branch
3. Installs `setup-envtest` and downloads appropriate binaries
4. Exports `KUBEBUILDER_ASSETS` for downstream test targets

No Go 1.25.x build cache workaround was present in this repo, so none was added.

Coverage directory creation is already handled by `build/run-unit-tests.sh` (`mkdir -p test/unit/coverage`), so no changes were needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)