### PR TITLE
Adopt shared envtest setup from sdk-go [release-2.16]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export PROJECT_DIR            = $(shell 'pwd')
 export BUILD_DIR              = $(PROJECT_DIR)/build
 export COMPONENT_SCRIPTS_PATH = $(BUILD_DIR)
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 export COMPONENT_NAME ?= $(shell cat ./COMPONENT_NAME 2> /dev/null)
 export COMPONENT_VERSION ?= $(shell cat ./COMPONENT_VERSION 2> /dev/null)
 
@@ -52,9 +54,14 @@ copyright-check:
 	@build/copyright-check.sh
 
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
 ## Runs go unit tests
-test:
+test: envtest-setup
 	@build/run-unit-tests.sh
 
 .PHONY: build


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target that uses the shared `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/ensure-envtest.sh) to automatically download and configure kubebuilder envtest binaries (kube-apiserver, etcd, kubectl)
- The `test` target now depends on `envtest-setup` to ensure `KUBEBUILDER_ASSETS` is properly configured before running unit tests
- The script auto-detects the required Kubernetes version from `go.mod` and downloads the matching envtest binaries, replacing the deprecated `storage.googleapis.com/kubebuilder-tools` method

## Changes

- **Makefile**: Added `ENSURE_ENVTEST_SCRIPT` variable pointing to the shared sdk-go script, added `envtest-setup` target, and made `test` depend on `envtest-setup`

## Test plan

- [ ] Verify `make envtest-setup` downloads envtest binaries and sets `KUBEBUILDER_ASSETS`
- [ ] Verify `make test` runs envtest setup before executing unit tests
- [ ] Verify binaries are cached in `_output/tools/bin` (already in `.gitignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)