### PR TITLE
fix: [acm-214] klusterlet-addon-controller-acm-214 - Konflux compliance failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/klusterlet-addon-controller
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.17.3


### PR DESCRIPTION
## Bug
https://redhat.atlassian.net/browse/ACM-31494

## Root Cause
The compiled binary in the image contains Go standard library vulnerabilities (e.g., GO-2026-4602, GO-2026-4601 in go1.25.5). Enterprise Contract scans detect these CVEs and fail the push pipeline.

## Fix
Bump the Go version in go.mod to the latest patched release (e.g., 1.25.8) so Konflux builds the binary without these standard library vulnerabilities.

## Auto-generated
This draft PR was automatically generated by server-foundation-agent based on bug triage analysis.
**Human review is required before merging.**

Co-Authored-By: server-foundation-agent <noreply@redhat.com>