### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,40 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+COPY . .
+RUN chmod g+w . && \
+  git config --global --add safe.directory "$PWD" && \
+  CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build ./cmd/manager && \
+  go test \
+    -covermode=atomic \
+    -coverpkg=github.com/stolostron/klusterlet-addon-controller/pkg/... \
+    -c -tags testrunmain ./cmd/manager \
+    -o manager-coverage
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+LABEL \
+    name="rhacm2/klusterlet-addon-controller-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    com.redhat.component="klusterlet-addon-controller" \
+    description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
+    io.k8s.description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
+    summary="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
+    io.k8s.display-name="Red Hat Advanced Cluster Management Klusterlet AddOn Controller" \
+    io.openshift.tags="mce acm ocm klusterlet-addon-controller"
+ENV IMAGE_MANIFEST_PATH=/
+
+ENV OPERATOR=/usr/local/bin/klusterlet-addon-controller \
+    USER_UID=10001 \
+    USER_NAME=klusterlet-addon-controller
+
+COPY --from=builder ./deploy/crds deploy/crds
+COPY --from=builder ./manager ${OPERATOR}
+COPY --from=builder ./manager-coverage ${OPERATOR}-coverage
+COPY --from=builder ./build/bin /usr/local/bin
+COPY --from=builder ./build/coverage-entrypoint-func.sh /usr/local/bin/coverage-entrypoint-func.sh
+
+RUN  /usr/local/bin/user_setup
+
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)