### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -4,7 +4,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 COPY . .
 RUN chmod g+w . && \
   git config --global --add safe.directory "$PWD" && \
-  go build ./cmd/manager && \
+  CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build ./cmd/manager && \
   go test \
     -covermode=atomic \
     -coverpkg=github.com/stolostron/klusterlet-addon-controller/pkg/... \


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847