### PR TITLE
Experiment: Test Red Hat Hardened core-runtime Image (release-acm-212)

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -11,7 +11,7 @@ RUN chmod g+w . && \
     -c -tags testrunmain ./cmd/manager \
     -o manager-coverage
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
 LABEL \
     name="rhacm2/klusterlet-addon-controller-rhel9" \
     cpe="cpe:/a:redhat:acm:2.12::el9" \


### PR DESCRIPTION
## Purpose
This is an **experimental PR** against the inactive **release-acm-212** application to test Red Hat's hardened images.

## Changes
- Switch runtime base image from `ubi9/ubi-minimal`
- To: `registry.access.redhat.com/hi/core-runtime:latest-openssl-fips`
- **Modified file:** `Dockerfile.rhtap` (ONLY file changed)

## Details
**Component:** klusterlet-addon-controller
**Target Release:** release-2.12 (inactive)
**Hardened Image:** core-runtime with FIPS-enabled OpenSSL

### Why This Component?
- Clean Dockerfile - only copies binaries
- No package manager usage detected
- Good candidate for hardened image compatibility testing

## Testing
- Target: Inactive release-acm-212 Konflux application
- Goal: Validate Konflux build success with hardened images
- Focus: FIPS compliance, runtime compatibility
- Reference: https://images.redhat.com/

## Notes
- This is for experimentation only
- Not intended for merge to active releases
- Monitoring Konflux build pipeline for compatibility
- Part of systematic testing across ACM 2.12 components
- **Only the Dockerfile was modified** - no other changes

/hold
/cc @gparvin