### PR TITLE
update to golang1.26

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: go/src/github.com/stolostron/klusterlet-addon-controller/go.mod
       - name: build
         run: make build
 
@@ -45,7 +45,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: go/src/github.com/stolostron/klusterlet-addon-controller/go.mod
       - name: unit
         run: make test
 
@@ -61,7 +61,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version-file: go/src/github.com/stolostron/klusterlet-addon-controller/go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: images

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -11,8 +11,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
-  GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/klusterlet-addon-controller/klusterlet-addon-controller/go'
 defaults:
   run:
@@ -31,7 +29,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: build
         run: make build
 
@@ -47,7 +45,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: unit
         run: make test
 
@@ -63,7 +61,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: images

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 COPY . .
 RUN chmod g+w . && \
   git config --global --add safe.directory "$PWD" && \

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -14,7 +14,6 @@ RUN chmod g+w . && \
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
     name="rhacm2/klusterlet-addon-controller-rhel9" \
-    cpe="cpe:/a:redhat:acm:2.16::el9" \
     com.redhat.component="klusterlet-addon-controller" \
     description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \
     io.k8s.description="Klusterlet AddOn controller is an conponent of RHACM, which manages the Klusterelet AddOns." \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ARG REMOTE_SOURCE
 ARG REMOTE_SOURCE_DIR

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/klusterlet-addon-controller
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.17.3


### PR DESCRIPTION
Also removes the old incorrect cpe value from Dockerfile.rhap - the cpe label will be inserted automatically by the common pipeline.